### PR TITLE
feat: Add preparatory work before connecting remote skill (#7519)

### DIFF
--- a/Composer/packages/client/__tests__/components/skill.test.tsx
+++ b/Composer/packages/client/__tests__/components/skill.test.tsx
@@ -16,36 +16,54 @@ jest.mock('../../src//utils/httpUtil');
 
 jest.mock('../../src/components/Modal/dialogStyle', () => ({}));
 
-let recoilInitState;
 const projectId = '123a.234';
 
-describe('Skill page', () => {
-  beforeEach(() => {
-    recoilInitState = ({ set }) => {
-      set(currentProjectIdState, projectId);
-
-      set(settingsState(projectId), {
-        luis: {
-          name: '',
-          authoringKey: '12345',
-          authoringEndpoint: 'testAuthoringEndpoint',
-          endpointKey: '12345',
-          endpoint: 'testEndpoint',
-          authoringRegion: 'westus',
-          defaultLanguage: 'en-us',
-          environment: 'composer',
-        },
-        qna: {
-          subscriptionKey: '12345',
-          qnaRegion: 'westus',
-          endpointKey: '',
-        },
-      });
-    };
-  });
-});
-
 describe('<SkillForm />', () => {
+  const recoilInitState = ({ set }) => {
+    set(currentProjectIdState, projectId);
+
+    set(settingsState(projectId), {
+      luis: {
+        name: '',
+        authoringKey: '12345',
+        authoringEndpoint: 'testAuthoringEndpoint',
+        endpointKey: '12345',
+        endpoint: 'testEndpoint',
+        authoringRegion: 'westus',
+        defaultLanguage: 'en-us',
+        environment: 'composer',
+      },
+      qna: {
+        subscriptionKey: '12345',
+        qnaRegion: 'westus',
+        endpointKey: '',
+      },
+      publishTargets: [
+        {
+          name: 'Test',
+          type: 'azurePublish',
+          configuration:
+            '{"name":"test","environment":"dev","tenantId":"xxx","runtimeIdentifier":"win-x64","resourceGroup":"<name of your resource group>","botName":"<name of your bot channel registration>","subscriptionId":"<id of your subscription>","region":"<region of your resource group>","settings":{"applicationInsights":{"InstrumentationKey":"<Instrumentation Key>"},"cosmosDb":{"cosmosDBEndpoint":"<endpoint url>","authKey":"<auth key>","databaseId":"botstate-db","containerId":"botstate-container"},"blobStorage":{"connectionString":"<connection string>","container":"<container>"}}}',
+          lastPublished: '2021-04-08T08:08:21.581Z',
+        },
+        {
+          name: 'Test1',
+          type: 'azurePublish',
+          configuration:
+            '{"name":"test1","environment":"dev","tenantId":"xxx","runtimeIdentifier":"win-x64","resourceGroup":"<name of your resource group>","botName":"<name of your bot channel registration>","subscriptionId":"<id of your subscription>","region":"<region of your resource group>","settings":{"applicationInsights":{"InstrumentationKey":"<Instrumentation Key>"},"cosmosDb":{"cosmosDBEndpoint":"<endpoint url>","authKey":"<auth key>","databaseId":"botstate-db","containerId":"botstate-container"},"blobStorage":{"connectionString":"<connection string>","container":"<container>"}}}',
+          lastPublished: '2021-04-08T07:23:29.077Z',
+        },
+        {
+          configuration:
+            '{"name":"test2","environment":"dev","tenantId":"xxx","runtimeIdentifier":"win-x64","resourceGroup":"<name of your resource group>","botName":"<name of your bot channel registration>","subscriptionId":"<id of your subscription>","region":"<region of your resource group>","settings":{"applicationInsights":{"InstrumentationKey":"<Instrumentation Key>"},"cosmosDb":{"cosmosDBEndpoint":"<endpoint url>","authKey":"<auth key>","databaseId":"botstate-db","containerId":"botstate-container"},"blobStorage":{"connectionString":"<connection string>","container":"<container>"}}}',
+          name: 'Test2',
+          type: 'azurePublish',
+          lastPublished: '2021-04-09T08:11:59.491Z',
+        },
+      ],
+    });
+  };
+
   it('should render the skill form, and update skill manifest URL', () => {
     try {
       jest.useFakeTimers();
@@ -55,7 +73,7 @@ describe('<SkillForm />', () => {
       const onDismiss = jest.fn();
       const addRemoteSkill = jest.fn();
       const addTriggerToRoot = jest.fn();
-      const { getByLabelText } = renderWithRecoil(
+      const { getByTestId, getByLabelText } = renderWithRecoil(
         <CreateSkillModal
           addRemoteSkill={addRemoteSkill}
           addTriggerToRoot={addTriggerToRoot}
@@ -65,10 +83,15 @@ describe('<SkillForm />', () => {
         recoilInitState
       );
 
+      const nextButton = getByTestId('SetAppIdNext');
+      nextButton.click();
+
       const urlInput = getByLabelText('Skill Manifest URL');
       act(() => {
         fireEvent.change(urlInput, {
-          target: { value: 'https://onenote-dev.azurewebsites.net/manifests/OneNoteSync-2-1-preview-1-manifest.json' },
+          target: {
+            value: 'https://onenote-dev.azurewebsites.net/manifests/OneNoteSync-2-1-preview-1-manifest.json',
+          },
         });
       });
 

--- a/Composer/packages/client/src/components/AddRemoteSkillModal/CreateSkillModal.tsx
+++ b/Composer/packages/client/src/components/AddRemoteSkillModal/CreateSkillModal.tsx
@@ -6,23 +6,35 @@ import formatMessage from 'format-message';
 import { PrimaryButton, DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { Stack, StackItem } from 'office-ui-fabric-react/lib/Stack';
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
+import { FontSizes } from '@uifabric/fluent-theme';
 import { useRecoilValue } from 'recoil';
 import debounce from 'lodash/debounce';
 import { isUsingAdaptiveRuntime, SDKKinds } from '@bfc/shared';
 import { DialogWrapper, DialogTypes } from '@bfc/ui-shared';
 import { Separator } from 'office-ui-fabric-react/lib/Separator';
 import { Dropdown, IDropdownOption, ResponsiveMode } from 'office-ui-fabric-react/lib/Dropdown';
+import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
 
 import { LoadingSpinner } from '../../components/LoadingSpinner';
-import { settingsState, designPageLocationState, dispatcherState, luFilesSelectorFamily } from '../../recoilModel';
+import {
+  settingsState,
+  designPageLocationState,
+  dispatcherState,
+  luFilesSelectorFamily,
+  publishTypesState,
+} from '../../recoilModel';
 import { addSkillDialog } from '../../constants';
 import httpClient from '../../utils/httpUtil';
 import TelemetryClient from '../../telemetry/TelemetryClient';
 import { TriggerFormData } from '../../utils/dialogUtil';
 import { selectIntentDialog } from '../../constants';
+import { isShowAuthDialog } from '../../utils/auth';
+import { AuthDialog } from '../Auth/AuthDialog';
+import { PublishProfileDialog } from '../../pages/botProject/create-publish-profile/PublishProfileDialog';
 
 import { SelectIntent } from './SelectIntent';
 import { SkillDetail } from './SkillDetail';
+import { SetAppId } from './SetAppId';
 
 export interface SkillFormDataErrors {
   endpoint?: string;
@@ -81,13 +93,31 @@ const getTriggerFormData = (intent: string, content: string): TriggerFormData =>
 
 const buttonStyle = { root: { marginLeft: '8px' } };
 
+const setAppIdDialogStyles = {
+  dialog: {
+    title: {
+      fontWeight: FontWeights.bold,
+      fontSize: FontSizes.size20,
+      paddingTop: '14px',
+      paddingBottom: '11px',
+    },
+    subText: {
+      fontSize: FontSizes.size14,
+      marginBottom: '0px',
+    },
+  },
+  modal: {
+    main: {
+      maxWidth: '80% !important',
+      width: '960px !important',
+    },
+  },
+};
 export const CreateSkillModal: React.FC<CreateSkillModalProps> = (props) => {
   const { projectId, addRemoteSkill, addTriggerToRoot, onDismiss } = props;
 
-  const [title, setTitle] = useState({
-    subText: '',
-    title: addSkillDialog.SKILL_MANIFEST_FORM.title,
-  });
+  const [title, setTitle] = useState(addSkillDialog.SET_APP_ID);
+  const [showSetAppIdDialog, setShowSetAppIdDialog] = useState(true);
   const [showIntentSelectDialog, setShowIntentSelectDialog] = useState(false);
   const [formData, setFormData] = useState<{ manifestUrl: string; endpointName: string }>({
     manifestUrl: '',
@@ -96,11 +126,16 @@ export const CreateSkillModal: React.FC<CreateSkillModalProps> = (props) => {
   const [formDataErrors, setFormDataErrors] = useState<SkillFormDataErrors>({});
   const [skillManifest, setSkillManifest] = useState<any | null>(null);
   const [showDetail, setShowDetail] = useState(false);
+  const [showAuthDialog, setShowAuthDialog] = useState(false);
+  const [createSkillDialogHidden, setCreateSkillDialogHidden] = useState(false);
 
-  const { languages, luFeatures, runtime } = useRecoilValue(settingsState(projectId));
+  const publishTypes = useRecoilValue(publishTypesState(projectId));
+  const { languages, luFeatures, runtime, publishTargets = [], MicrosoftAppId } = useRecoilValue(
+    settingsState(projectId)
+  );
   const { dialogId } = useRecoilValue(designPageLocationState(projectId));
   const luFiles = useRecoilValue(luFilesSelectorFamily(projectId));
-  const { updateRecognizer } = useRecoilValue(dispatcherState);
+  const { updateRecognizer, setMicrosoftAppProperties, setPublishTargets } = useRecoilValue(dispatcherState);
 
   const debouncedValidateManifestURl = useRef(debounce(validateManifestUrl, 500)).current;
 
@@ -162,6 +197,31 @@ export const CreateSkillModal: React.FC<CreateSkillModalProps> = (props) => {
     }
   };
 
+  const handleDismiss = () => {
+    setShowSetAppIdDialog(true);
+    onDismiss();
+  };
+
+  const handleGotoAddSkill = (publishTargetName: string) => {
+    const profileTarget = publishTargets.find((target) => target.name === publishTargetName);
+    const configuration = JSON.parse(profileTarget?.configuration || '');
+    setMicrosoftAppProperties(
+      projectId,
+      configuration.settings.MicrosoftAppId,
+      configuration.settings.MicrosoftAppPassword
+    );
+
+    setShowSetAppIdDialog(false);
+    setTitle({
+      subText: '',
+      title: addSkillDialog.SKILL_MANIFEST_FORM.title,
+    });
+  };
+
+  const handleGotoCreateProfile = () => {
+    isShowAuthDialog(true) ? setShowAuthDialog(true) : setCreateSkillDialogHidden(true);
+  };
+
   useEffect(() => {
     if (skillManifest?.endpoints) {
       setFormData({
@@ -171,108 +231,161 @@ export const CreateSkillModal: React.FC<CreateSkillModalProps> = (props) => {
     }
   }, [skillManifest]);
 
+  useEffect(() => {
+    if (MicrosoftAppId) {
+      setShowSetAppIdDialog(false);
+      setTitle({
+        subText: '',
+        title: addSkillDialog.SKILL_MANIFEST_FORM.title,
+      });
+    }
+  }, [MicrosoftAppId]);
+
   return (
-    <DialogWrapper isOpen dialogType={DialogTypes.CreateFlow} onDismiss={onDismiss} {...title}>
-      {showIntentSelectDialog ? (
-        <SelectIntent
-          dialogId={dialogId}
-          languages={languages}
-          luFeatures={luFeatures}
-          manifest={skillManifest}
-          projectId={projectId}
-          rootLuFiles={luFiles}
-          onBack={() => {
-            setTitle({
-              subText: '',
-              title: addSkillDialog.SKILL_MANIFEST_FORM.title,
-            });
-            setShowIntentSelectDialog(false);
-          }}
-          onDismiss={onDismiss}
-          onSubmit={handleSubmit}
-          onUpdateTitle={setTitle}
-        />
-      ) : (
-        <Fragment>
-          <div style={{ marginBottom: '16px' }}>
-            {addSkillDialog.SKILL_MANIFEST_FORM.subText('https://aka.ms/bf-composer-docs-publish-bot')}
-          </div>
-          <Separator />
-          <Stack horizontal horizontalAlign="start" styles={{ root: { height: 300 } }}>
-            <div style={{ width: '50%' }}>
-              <TextField
-                required
-                errorMessage={formDataErrors.manifestUrl}
-                label={formatMessage('Skill Manifest URL')}
-                placeholder={formatMessage('Ask the skill owner for the URL and provide your bot’s App ID')}
-                value={formData.manifestUrl || ''}
-                onChange={handleManifestUrlChange}
-              />
-              {skillManifest?.endpoints?.length > 1 && (
-                <Dropdown
-                  defaultSelectedKey={skillManifest.endpoints[0].name}
-                  label={formatMessage('Endpoints')}
-                  options={options}
-                  responsiveMode={ResponsiveMode.large}
-                  onChange={(e, option?: IDropdownOption) => {
-                    if (option) {
-                      setFormData({
-                        ...formData,
-                        endpointName: option.key as string,
-                      });
-                    }
-                  }}
-                />
-              )}
+    <Fragment>
+      <DialogWrapper
+        dialogType={showSetAppIdDialog ? DialogTypes.Customer : DialogTypes.CreateFlow}
+        isOpen={!createSkillDialogHidden}
+        onDismiss={handleDismiss}
+        {...title}
+        customerStyle={setAppIdDialogStyles}
+      >
+        {showSetAppIdDialog && (
+          <Fragment>
+            <Separator styles={{ root: { marginBottom: '20px' } }} />
+            <SetAppId
+              projectId={projectId}
+              onDismiss={handleDismiss}
+              onGotoCreateProfile={handleGotoCreateProfile}
+              onNext={handleGotoAddSkill}
+            />
+          </Fragment>
+        )}
+        {showIntentSelectDialog && (
+          <SelectIntent
+            dialogId={dialogId}
+            languages={languages}
+            luFeatures={luFeatures}
+            manifest={skillManifest}
+            projectId={projectId}
+            rootLuFiles={luFiles}
+            onBack={() => {
+              setTitle({
+                subText: '',
+                title: addSkillDialog.SKILL_MANIFEST_FORM.title,
+              });
+              setShowIntentSelectDialog(false);
+            }}
+            onDismiss={handleDismiss}
+            onSubmit={handleSubmit}
+            onUpdateTitle={setTitle}
+          />
+        )}
+        {!showIntentSelectDialog && !showSetAppIdDialog && (
+          <Fragment>
+            <div style={{ marginBottom: '16px' }}>
+              {addSkillDialog.SKILL_MANIFEST_FORM.subText('https://aka.ms/bf-composer-docs-publish-bot')}
             </div>
-            {showDetail && (
-              <Fragment>
-                <Separator vertical styles={{ root: { padding: '0px 20px' } }} />
-                <div style={{ minWidth: '50%' }}>
-                  {skillManifest ? <SkillDetail manifest={skillManifest} /> : <LoadingSpinner />}
-                </div>
-              </Fragment>
-            )}
-          </Stack>
-          <Stack>
             <Separator />
-            <StackItem align={'end'}>
-              <DefaultButton data-testid="SkillFormCancel" text={formatMessage('Cancel')} onClick={onDismiss} />
-              {skillManifest ? (
-                isUsingAdaptiveRuntime(runtime) &&
-                luFiles.length > 0 &&
-                skillManifest.dispatchModels?.intents?.length > 0 ? (
-                  <PrimaryButton
-                    disabled={formDataErrors.manifestUrl ? true : false}
-                    styles={buttonStyle}
-                    text={formatMessage('Next')}
-                    onClick={(event) => {
-                      setTitle(selectIntentDialog.SELECT_INTENT(dialogId, skillManifest.name));
-                      setShowIntentSelectDialog(true);
+            <Stack horizontal horizontalAlign="start" styles={{ root: { height: 300 } }}>
+              <div style={{ width: '50%' }}>
+                <TextField
+                  required
+                  errorMessage={formDataErrors.manifestUrl}
+                  label={formatMessage('Skill Manifest URL')}
+                  placeholder={formatMessage('Ask the skill owner for the URL and provide your bot’s App ID')}
+                  value={formData.manifestUrl || ''}
+                  onChange={handleManifestUrlChange}
+                />
+                {skillManifest?.endpoints?.length > 1 && (
+                  <Dropdown
+                    defaultSelectedKey={skillManifest.endpoints[0].name}
+                    label={formatMessage('Endpoints')}
+                    options={options}
+                    responsiveMode={ResponsiveMode.large}
+                    onChange={(e, option?: IDropdownOption) => {
+                      if (option) {
+                        setFormData({
+                          ...formData,
+                          endpointName: option.key as string,
+                        });
+                      }
                     }}
                   />
+                )}
+              </div>
+              {showDetail && (
+                <Fragment>
+                  <Separator vertical styles={{ root: { padding: '0px 20px' } }} />
+                  <div style={{ minWidth: '50%' }}>
+                    {skillManifest ? <SkillDetail manifest={skillManifest} /> : <LoadingSpinner />}
+                  </div>
+                </Fragment>
+              )}
+            </Stack>
+            <Stack>
+              <Separator />
+              <StackItem align={'end'}>
+                <DefaultButton data-testid="SkillFormCancel" text={formatMessage('Cancel')} onClick={onDismiss} />
+                {skillManifest ? (
+                  isUsingAdaptiveRuntime(runtime) &&
+                  luFiles.length > 0 &&
+                  skillManifest.dispatchModels?.intents?.length > 0 ? (
+                    <PrimaryButton
+                      disabled={formDataErrors.manifestUrl ? true : false}
+                      styles={buttonStyle}
+                      text={formatMessage('Next')}
+                      onClick={(event) => {
+                        setTitle(selectIntentDialog.SELECT_INTENT(dialogId, skillManifest.name));
+                        setShowIntentSelectDialog(true);
+                      }}
+                    />
+                  ) : (
+                    <PrimaryButton
+                      styles={buttonStyle}
+                      text={formatMessage('Done')}
+                      onClick={(event) => {
+                        addRemoteSkill(formData.manifestUrl, formData.endpointName);
+                      }}
+                    />
+                  )
                 ) : (
                   <PrimaryButton
+                    disabled={!formData.manifestUrl || formDataErrors.manifestUrl !== undefined}
                     styles={buttonStyle}
-                    text={formatMessage('Done')}
-                    onClick={(event) => {
-                      addRemoteSkill(formData.manifestUrl, formData.endpointName);
-                    }}
+                    text={formatMessage('Next')}
+                    onClick={validateUrl}
                   />
-                )
-              ) : (
-                <PrimaryButton
-                  disabled={!formData.manifestUrl || formDataErrors.manifestUrl !== undefined}
-                  styles={buttonStyle}
-                  text={formatMessage('Next')}
-                  onClick={validateUrl}
-                />
-              )}
-            </StackItem>
-          </Stack>
-        </Fragment>
+                )}
+              </StackItem>
+            </Stack>
+          </Fragment>
+        )}
+      </DialogWrapper>
+      {showAuthDialog && (
+        <AuthDialog
+          needGraph
+          next={() => {
+            setCreateSkillDialogHidden(true);
+          }}
+          onDismiss={() => {
+            setShowAuthDialog(false);
+          }}
+        />
       )}
-    </DialogWrapper>
+      {createSkillDialogHidden ? (
+        <PublishProfileDialog
+          closeDialog={() => {
+            setCreateSkillDialogHidden(false);
+          }}
+          current={null}
+          projectId={projectId}
+          setPublishTargets={setPublishTargets}
+          targets={publishTargets || []}
+          types={publishTypes}
+        />
+      ) : null}
+    </Fragment>
   );
 };
 

--- a/Composer/packages/client/src/components/AddRemoteSkillModal/SetAppId.tsx
+++ b/Composer/packages/client/src/components/AddRemoteSkillModal/SetAppId.tsx
@@ -1,0 +1,249 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/** @jsx jsx */
+import { jsx } from '@emotion/core';
+import formatMessage from 'format-message';
+import { FontIcon } from 'office-ui-fabric-react/lib/Icon';
+import { Link } from 'office-ui-fabric-react/lib/Link';
+import { useRecoilValue } from 'recoil';
+import { Fragment, useEffect, useMemo, useState } from 'react';
+import { CommunicationColors, NeutralColors, SharedColors } from '@uifabric/fluent-theme';
+import { IDropdownOption, Dropdown } from 'office-ui-fabric-react/lib/Dropdown';
+import { Stack, StackItem } from 'office-ui-fabric-react/lib/Stack';
+import { Label } from 'office-ui-fabric-react/lib/Label';
+import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
+import { FontSizes } from '@uifabric/fluent-theme';
+import { DefaultButton, IconButton, PrimaryButton } from 'office-ui-fabric-react/lib/Button';
+import { Separator } from 'office-ui-fabric-react/lib/Separator';
+import { navigate } from '@reach/router';
+
+import { settingsState, botDisplayNameState } from '../../recoilModel';
+
+const buttonStyle = { root: { marginLeft: '8px' } };
+
+type SetAppIdProps = {
+  projectId: string;
+  onDismiss: () => void;
+  onNext: (targetName: string) => void;
+  onGotoCreateProfile: () => void;
+};
+
+const getCreateProfileDescription = (botName, handleCreateProfile) => ({
+  iconProps: {
+    iconName: 'Error',
+    color: SharedColors.orange20,
+  },
+  title: formatMessage(`Add publishing profile for {botName}`, { botName }),
+  description: formatMessage(
+    'A publishing profile contains the information necessary to provision and publish your bot, including its App ID. '
+  ),
+  link: {
+    text: formatMessage('Create profile'),
+    onClick: handleCreateProfile,
+  },
+});
+
+const manifestUrl = () => ({
+  title: formatMessage('Enter skill manifest URL'),
+  description: formatMessage(
+    "To connect to a skill, your bot needs the information captured in the skill's manifest. Contact the author or publisher of the skill for this information."
+  ),
+});
+
+const appIdInfo = () => ({
+  title: formatMessage('Ensure your bot’s Microsoft App ID is on the skill’s allowed callers list'),
+  description: formatMessage(
+    "For security purposes, your bot can only call a skill if its Microsoft App ID is in the skill's allowed callers list. Once you create a publishing profilem share your bot’s App ID with the skill’s author to add it. You may also need to include the skill’s App Id in the root bot’s allowed callers list."
+  ),
+});
+
+type RenderItemProps = {
+  title: string;
+  description: string;
+  iconProps?: {
+    iconName: string;
+    color: string;
+  };
+  link?: {
+    text: string;
+    onClick: () => void;
+  };
+};
+
+const renderItem = ({
+  title,
+  description,
+  link,
+  iconProps = { iconName: 'Completed', color: SharedColors.cyanBlue10 },
+}: RenderItemProps) => {
+  return (
+    <div css={{ display: 'flex', marginBottom: '20px' }}>
+      <FontIcon
+        iconName={iconProps.iconName}
+        style={{ color: iconProps.color, fontSize: '18px', margin: '4px 12px 0 0' }}
+      />
+      <div css={{ fontSize: '14px', lineHeight: '20px' }}>
+        <div style={{ color: NeutralColors.gray160, fontWeight: 600, marginBottom: '5px' }}>{title}</div>
+        <div style={{ color: NeutralColors.gray130 }}>{description}</div>
+        {link && <Link onClick={link.onClick}>{link.text}</Link>}
+      </div>
+    </div>
+  );
+};
+type CustomLabelProps = {
+  label: string;
+  description: string;
+  required?: boolean;
+};
+const CustomLabel: React.FC<CustomLabelProps> = ({ label, description, required = false }) => {
+  return (
+    <Stack horizontal verticalAlign="center">
+      <Label
+        required={required}
+        styles={{ root: { marginRight: '4px', selectors: { '::after': { paddingRight: '0px' } } } }}
+      >
+        {label}
+      </Label>
+      <TooltipHost content={description}>
+        <FontIcon iconName="Info" style={{ fontSize: FontSizes.size12 }} />
+      </TooltipHost>
+    </Stack>
+  );
+};
+
+const renderMicrosoftAppId = (MicrosoftAppId: string, label: string, description: string): JSX.Element => {
+  return (
+    <Fragment>
+      <CustomLabel description={description} label={label} />
+      <div
+        style={{
+          color: NeutralColors.gray90,
+          backgroundColor: NeutralColors.gray20,
+          fontSize: FontSizes.size14,
+          display: 'flex',
+          justifyContent: 'space-between',
+          lineHeight: '30px',
+          paddingLeft: '10px',
+          width: '394px',
+        }}
+      >
+        {MicrosoftAppId}
+        <IconButton
+          iconProps={{ iconName: 'copy' }}
+          styles={{ icon: { fontSize: FontSizes.size12, color: CommunicationColors.primary } }}
+          onClick={() => navigator.clipboard.writeText(MicrosoftAppId || '')}
+        />
+      </div>
+    </Fragment>
+  );
+};
+export const SetAppId: React.FC<SetAppIdProps> = (props) => {
+  const { projectId, onDismiss, onNext, onGotoCreateProfile } = props;
+  const settings = useRecoilValue(settingsState(projectId));
+  const botName = useRecoilValue(botDisplayNameState(projectId));
+  const { publishTargets = [] } = settings;
+  const publishTargetOptions: IDropdownOption[] = publishTargets.map((target) => ({
+    key: target.name,
+    text: target.name,
+  }));
+
+  const handleNavigateToDevelopmentResources = () => {
+    navigate(`/bot/${projectId}/botProjectsSettings/#LuisQna`);
+  };
+
+  const setMSAppIdAndPassword = () => ({
+    iconProps: {
+      iconName: 'Error',
+      color: SharedColors.orange20,
+    },
+    title: formatMessage('Select App ID and password'),
+    description: formatMessage(
+      'To ensure a secure connection, the remote skill needs to know the Microsoft App ID of your bot. '
+    ),
+    link: {
+      text: formatMessage('Select App ID and password'),
+      onClick: handleNavigateToDevelopmentResources,
+    },
+  });
+
+  const [currentTargetName, setCurrentTargetName] = useState(publishTargets.length === 0 ? '' : publishTargets[0].name);
+
+  const appId = useMemo(() => {
+    if (publishTargets.length === 0) return '';
+
+    const { settings } = JSON.parse(
+      publishTargets.find((target) => target.name === currentTargetName)?.configuration || '{}'
+    );
+    return settings?.MicrosoftAppId || '';
+  }, [publishTargets, currentTargetName]);
+
+  useEffect(() => {
+    if (publishTargets.length > 0) {
+      setCurrentTargetName(publishTargets[0].name);
+    }
+  }, [publishTargets.length]);
+
+  return (
+    <Fragment>
+      {publishTargets.length === 0 ? (
+        <Fragment>
+          {renderItem(getCreateProfileDescription(botName, onGotoCreateProfile))}
+          {renderItem(setMSAppIdAndPassword())}
+          {renderItem(appIdInfo())}
+          {renderItem(manifestUrl())}
+        </Fragment>
+      ) : (
+        <Fragment>
+          {renderItem(appIdInfo())}
+          {publishTargets.length === 1 ? (
+            <div style={{ margin: '0 0 40px 30px' }}>
+              {renderMicrosoftAppId(
+                appId,
+                formatMessage('Your bot’s Microsoft App ID'),
+                formatMessage('Microsoft App ID')
+              )}
+            </div>
+          ) : (
+            <div style={{ display: 'flex', margin: '0 0 40px 30px' }}>
+              <div style={{ marginRight: '20px' }}>
+                <CustomLabel
+                  required
+                  description={formatMessage('Publish profile')}
+                  label={formatMessage('Publish profile')}
+                />
+                <Dropdown
+                  options={publishTargetOptions}
+                  placeholder={formatMessage('Select an option')}
+                  selectedKey={currentTargetName}
+                  styles={{ root: { width: '187px' } }}
+                  onChange={(_, option) => {
+                    setCurrentTargetName(option?.key as string);
+                  }}
+                />
+              </div>
+              <div>
+                {renderMicrosoftAppId(appId, formatMessage('Microsoft App Id'), formatMessage('Microsoft App Id'))}
+              </div>
+            </div>
+          )}
+          {renderItem(setMSAppIdAndPassword())}
+          {renderItem(manifestUrl())}
+        </Fragment>
+      )}
+      <Stack>
+        <Separator />
+        <StackItem align={'end'}>
+          <DefaultButton data-testid="SkillFormCancel" text={formatMessage('Cancel')} onClick={onDismiss} />
+          <PrimaryButton
+            data-testid="SetAppIdNext"
+            disabled={publishTargets.length === 0}
+            styles={buttonStyle}
+            text={formatMessage('Next')}
+            onClick={() => onNext(currentTargetName)}
+          />
+        </StackItem>
+      </Stack>
+    </Fragment>
+  );
+};

--- a/Composer/packages/client/src/constants.tsx
+++ b/Composer/packages/client/src/constants.tsx
@@ -323,6 +323,14 @@ export const MultiLanguagesDialog = {
 };
 
 export const addSkillDialog = {
+  get SET_APP_ID() {
+    return {
+      title: formatMessage('Connect to a skill'),
+      subText: formatMessage(
+        "To connect to a skill, your bot needs the information captured in the skill's manifest, and, for secure access, the skill needs to know your bot's App ID. Follow the steps below to proceed."
+      ),
+    };
+  },
   get SKILL_MANIFEST_FORM() {
     return {
       title: formatMessage('Add a skill'),

--- a/Composer/packages/client/src/pages/botProject/BotProjectsSettingsTabView.tsx
+++ b/Composer/packages/client/src/pages/botProject/BotProjectsSettingsTabView.tsx
@@ -76,9 +76,13 @@ export const BotProjectSettingsTabView: React.FC<RouteComponentProps<{
   useEffect(() => {
     if (scrollToSectionId) {
       const htmlIdTagName = scrollToSectionId.replace('#', '');
-      for (const key in PivotItemKey) {
-        if (idsInTab[key].includes(htmlIdTagName)) {
-          setSelectedKey(key as PivotItemKey);
+      if (idsInTab[htmlIdTagName]) {
+        setSelectedKey(PivotItemKey[htmlIdTagName]);
+      } else {
+        for (const key in PivotItemKey) {
+          if (idsInTab[key].includes(htmlIdTagName)) {
+            setSelectedKey(key as PivotItemKey);
+          }
         }
       }
     }

--- a/Composer/packages/client/src/pages/botProject/PublishTargets.tsx
+++ b/Composer/packages/client/src/pages/botProject/PublishTargets.tsx
@@ -64,7 +64,7 @@ type PublishTargetsProps = {
 export const PublishTargets: React.FC<PublishTargetsProps> = (props) => {
   const { projectId, scrollToSectionId = '' } = props;
   const { publishTargets } = useRecoilValue(settingsState(projectId));
-  const { getPublishTargetTypes, setPublishTargets } = useRecoilValue(dispatcherState);
+  const { setPublishTargets } = useRecoilValue(dispatcherState);
   const publishTypes = useRecoilValue(publishTypesState(projectId));
 
   const [showPublishDialog, setShowingPublishDialog] = useState(false);
@@ -89,12 +89,6 @@ export const PublishTargets: React.FC<PublishTargetsProps> = (props) => {
       }
     }
   }, [location, publishTargets]);
-
-  useEffect(() => {
-    if (projectId) {
-      getPublishTargetTypes(projectId);
-    }
-  }, [projectId]);
 
   useEffect(() => {
     if (publishTargetsRef.current && scrollToSectionId === '#addNewPublishProfile') {

--- a/Composer/packages/client/src/pages/publish/Publish.tsx
+++ b/Composer/packages/client/src/pages/publish/Publish.tsx
@@ -65,7 +65,6 @@ const Publish: React.FC<RouteComponentProps<{ projectId: string; targetName?: st
   const {
     getPublishHistory,
     getPublishStatusV2,
-    getPublishTargetTypes,
     setPublishTargets,
     publishToTarget,
     setQnASettings,
@@ -104,18 +103,6 @@ const Publish: React.FC<RouteComponentProps<{ projectId: string; targetName?: st
   const selectedBots = useMemo(() => {
     return currentBotList.filter((bot) => checkedSkillIds.some((id) => bot.id === id));
   }, [checkedSkillIds]);
-
-  // The publishTypes are loaded from the server and put into the publishTypesState per project
-  // The botProjectSpaceSelector maps the publishTypes to the project bots.
-  // The localBotsDataSelector uses botProjectSpaceSelector
-  // The botPropertyData uses localBotsDataSelector
-  // When the botPropertyData is used (like in the canPull method), the publishTypes must be loaded for the current project.
-  // Otherwise the botPropertyData publishTypes will always be empty and this component won't function properly.
-  useEffect(() => {
-    if (projectId) {
-      getPublishTargetTypes(projectId);
-    }
-  }, [projectId]);
 
   const canPull = useMemo(() => {
     return selectedBots.some((bot) => {

--- a/Composer/packages/client/src/recoilModel/dispatchers/setting.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/setting.ts
@@ -170,6 +170,15 @@ export const settingsDispatcher = () => {
     }
   );
 
+  const setMicrosoftAppProperties = useRecoilCallback(
+    ({ set }: CallbackInterface) => async (projectId: string, appId: string, password: string) => {
+      set(settingsState(projectId), (currentValue) => ({
+        ...currentValue,
+        MicrosoftAppId: appId,
+        MicrosoftAppPassword: password,
+      }));
+    }
+  );
   const setCustomRuntime = useRecoilCallback(() => async (projectId: string, isOn: boolean) => {
     setRuntimeField(projectId, 'customRuntime', isOn);
   });
@@ -270,6 +279,7 @@ export const settingsDispatcher = () => {
     setRuntimeSettings,
     setPublishTargets,
     setRuntimeField,
+    setMicrosoftAppProperties,
     setImportedLibraries,
     setCustomRuntime,
     setQnASettings,

--- a/Composer/packages/client/src/recoilModel/dispatchers/utils/project.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/utils/project.ts
@@ -767,6 +767,8 @@ export const openRootBotAndSkills = async (callbackHelpers: CallbackInterface, d
 
   set(botNameIdentifierState(rootBotProjectId), camelCase(name));
   set(botProjectIdsState, [rootBotProjectId]);
+  // Get the publish types on opening
+  dispatcher.getPublishTargetTypes(rootBotProjectId);
   // Get the status of the bot on opening if it was opened and run in another window.
   dispatcher.getPublishStatus(rootBotProjectId, defaultPublishConfig);
   if (botFiles?.botProjectSpaceFiles?.length) {

--- a/Composer/packages/lib/ui-shared/src/components/DialogWrapper.tsx
+++ b/Composer/packages/lib/ui-shared/src/components/DialogWrapper.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { Dialog, DialogType, IDialogProps } from 'office-ui-fabric-react/lib/Dialog';
 import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
 import { FontSizes } from '@uifabric/fluent-theme';
@@ -109,13 +109,7 @@ export const DialogWrapper: React.FC<DialogWrapperProps> = (props) => {
   /* add customer styles to the array */
   styles[DialogTypes.Customer] = customerStyle;
 
-  const [currentStyle, setStyle] = useState(styles[dialogType]);
-
-  useEffect(() => {
-    if (dialogType) {
-      setStyle(styles[dialogType]);
-    }
-  }, [dialogType]);
+  const currentStyle = styles[dialogType];
 
   if (!isOpen) {
     return null;

--- a/Composer/packages/server/src/locales/en-US.json
+++ b/Composer/packages/server/src/locales/en-US.json
@@ -515,6 +515,9 @@
   "been_used_5daccdb2": {
     "message": "Been used"
   },
+  "before_we_begin_7ae9c242": {
+    "message": "Before we begin"
+  },
   "begin_a_new_dialog_60249bd8": {
     "message": "Begin a new dialog"
   },
@@ -571,6 +574,9 @@
   },
   "bot_files_created_986109df": {
     "message": "Bot files created"
+  },
+  "bot_framework_composer_2_0_provides_more_built_in__c6abf11c": {
+    "message": "Bot Framework Composer 2.0 provides more built-in capabilities so you can build complex bots quickly. Update to Composer 2.0 for advanced bot templates, prebuilt components, and a runtime that is fully extensible through packages."
   },
   "bot_framework_composer_fae721be": {
     "message": "Bot Framework Composer"
@@ -745,6 +751,12 @@
   },
   "component_stacktrace_e24b1983": {
     "message": "Component Stacktrace:"
+  },
+  "components_of_kind_kind_are_not_supported_replace__de47f868": {
+    "message": "Components of $kind \"{ kind }\" are not supported. Replace with a different component or create a custom component."
+  },
+  "composer_2_0_is_now_available_113ed532": {
+    "message": "Composer 2.0 is now available!"
   },
   "composer_cannot_yet_translate_your_bot_automatical_2d54081b": {
     "message": "Composer cannot yet translate your bot automatically.\nTo create a translation manually, Composer will create a copy of your bot’s content with the name of the additional language. This content can then be translated without affecting the original bot logic or flow and you can switch between languages to ensure the responses are correctly and appropriately translated."
@@ -950,6 +962,9 @@
   "create_a_publishing_profile_a79c6808": {
     "message": "Create a publishing profile"
   },
+  "create_a_publishing_profile_for_botname_b82f4386": {
+    "message": "Create a publishing profile for { botName }"
+  },
   "create_a_skill_in_your_bot_d7659e6b": {
     "message": "Create a skill in your bot"
   },
@@ -1054,6 +1069,9 @@
   },
   "date_time_input_aa8ad315": {
     "message": "Date time input"
+  },
+  "deactivated_action_1da615d0": {
+    "message": "Deactivated action."
   },
   "debug_break_46cb5adb": {
     "message": "Debug Break"
@@ -1412,6 +1430,9 @@
   "endpoints_ff946539": {
     "message": "Endpoints"
   },
+  "ensure_your_bot_s_microsoft_app_id_is_on_the_skill_a73799fb": {
+    "message": "Ensure your bot’s Microsoft App ID is on the skill’s allowed callers list"
+  },
   "enter_a_manifest_url_to_add_a_new_skill_to_your_bo_eb966c95": {
     "message": "Enter a manifest URL to add a new skill to your bot."
   },
@@ -1682,6 +1703,9 @@
   "for_properties_of_type_list_or_enum_your_bot_accep_9e7649c6": {
     "message": "For properties of type list (or enum), your bot accepts only the values you define. After your dialog is generated, you can provide synonyms for each value."
   },
+  "for_security_purposes_your_bot_can_only_call_a_ski_4b0c81e0": {
+    "message": "For security purposes your bot can only call a skill if it’s Microsoft App Id is in apps allowed callers list. Once you create a publishing profile share your bot’s App ID with the skill’s author to add it to the skill’s allowed callers list. You may also need to include the skill’s app Id in the root bot’s allowed callers list."
+  },
   "form_b674666c": {
     "message": "form"
   },
@@ -1750,6 +1774,9 @@
   },
   "get_a_new_copy_of_the_runtime_code_84970bf": {
     "message": "Get a new copy of the runtime code"
+  },
+  "get_a_skill_manifest_url_from_the_skill_s_author_7771e8b4": {
+    "message": "Get a skill manifest URL from the skill’s author"
   },
   "get_activity_members_11339605": {
     "message": "Get activity members"
@@ -1846,6 +1873,9 @@
   },
   "if_you_already_have_a_qna_account_provide_the_info_466d6a4b": {
     "message": "If you already have a QNA account, provide the information below. If you do not have an account yet, create a (free) account first."
+  },
+  "if_you_have_created_custom_components_you_might_ne_dc7cf128": {
+    "message": "If you have created custom components, you might need to rebuild them. <a>Learn more about custom components.</a>"
   },
   "if_you_would_like_to_try_again_or_select_from_exis_f2f894b4": {
     "message": "If you would like to try again, or select from existing resources, please click “Back”."
@@ -2080,6 +2110,9 @@
   },
   "learn_more_about_activities_134f453d": {
     "message": "Learn more about activities"
+  },
+  "learn_more_about_custom_actions_e7aa69e9": {
+    "message": "Learn more about custom actions"
   },
   "learn_more_about_endpoints_df156708": {
     "message": "Learn more about endpoints"
@@ -2552,6 +2585,9 @@
   "not_yet_published_669e37b3": {
     "message": "Not yet published"
   },
+  "note_if_your_bot_is_using_custom_actions_they_will_a500ed2": {
+    "message": "Note: If your bot is using custom actions, they will not be supported in Composer 2.0. <a>Learn more about updating to Composer 2.0.</a>"
+  },
   "notifications_cbfa7704": {
     "message": "Notifications"
   },
@@ -2729,6 +2765,9 @@
   "please_select_a_trigger_type_67417abb": {
     "message": "Please select a trigger type"
   },
+  "please_setup_the_following_to_ensure_we_can_connec_2c5a2acb": {
+    "message": "Please setup the following to ensure we can connect to your remote skill successfully"
+  },
   "pop_out_editor_5528a187": {
     "message": "Pop out editor"
   },
@@ -2857,6 +2896,9 @@
   },
   "publish_models_9a36752a": {
     "message": "Publish models"
+  },
+  "publish_profile_a4e8f07b": {
+    "message": "Publish profile"
   },
   "publish_selected_bots_825bc03a": {
     "message": "Publish selected bots"
@@ -3116,6 +3158,9 @@
   "review_and_generate_63dec712": {
     "message": "Review and generate"
   },
+  "review_deactivated_custom_actions_8db7540c": {
+    "message": "Review deactivated custom actions"
+  },
   "review_your_template_readme_2d6eae1e": {
     "message": "Review your template readme"
   },
@@ -3178,9 +3223,6 @@
   },
   "schema_24739a48": {
     "message": "Schema"
-  },
-  "schema_definition_not_found_in_sdk_schema_1102ce9b": {
-    "message": "Schema definition not found in sdk.schema."
   },
   "schemaid_doesn_t_exists_select_an_schema_to_edit_o_9cccc954": {
     "message": "{ schemaId } doesn''t exists, select an schema to edit or create a new one"
@@ -3263,6 +3305,9 @@
   "select_an_event_type_3d7108f1": {
     "message": "Select an event type"
   },
+  "select_an_option_9f5dfb55": {
+    "message": "Select an option"
+  },
   "select_an_schema_to_edit_or_create_a_new_one_59c7326a": {
     "message": "Select an schema to edit or create a new one"
   },
@@ -3317,6 +3362,9 @@
   "select_your_azure_directory_then_choose_the_subscr_d51f6201": {
     "message": "Select your Azure directory, then choose the subscription where your existing { service } resource is located."
   },
+  "select_your_microsoft_app_id_and_password_74918f5d": {
+    "message": "Select your Microsoft App ID and Password"
+  },
   "selection_field_86d1dc94": {
     "message": "selection field"
   },
@@ -3367,6 +3415,9 @@
   },
   "set_up_service_b6d23e54": {
     "message": "Set up { service }"
+  },
+  "set_your_microsoft_app_id_and_password_46b5628c": {
+    "message": "Set your Microsoft App ID and Password"
   },
   "setting_things_up_8022afe8": {
     "message": "Setting things up..."
@@ -3821,6 +3872,9 @@
   "title_ee03d132": {
     "message": "Title"
   },
+  "to_connect_to_a_skill_you_will_need_a_skill_s_mani_3d163597": {
+    "message": "To connect to a skill you will need a skill’s manifest URL. Contact the skill’s author to get the URL and paste it in the next step."
+  },
   "to_connect_to_a_skill_your_bot_needs_the_informati_f1b738ec": {
     "message": "To connect to a skill, your bot needs the information captured in the skill''s manifest of the bot, and, for secure access, the skill needs to know your bot''s AppID. <link>Learn more.</link>"
   },
@@ -3895,6 +3949,9 @@
   },
   "total_plural_1_starting_bot_other_starting_bots_ru_3d173401": {
     "message": "{ total, plural,\n     =1 {Starting bot..}\n  other {Starting bots.. ({ running }/{ total } running)}\n}"
+  },
+  "total_plural_1_stopping_bot_other_stopping_bots_ru_f6afe9bd": {
+    "message": "{ total, plural,\n     =1 {Stopping bot..}\n  other {Stopping bots.. ({ running }/{ total } running)}\n}"
   },
   "trigger_f0ee1fbf": {
     "message": "Trigger"
@@ -4004,8 +4061,14 @@
   "update_activity_2b05e6c6": {
     "message": "Update activity"
   },
+  "update_and_restart_b236a67": {
+    "message": "Update and restart"
+  },
   "update_available_b637d767": {
     "message": "Update available"
+  },
+  "update_cancelled_auto_update_has_been_turned_off_f_7f7e08d7": {
+    "message": "Update cancelled. Auto-update has been turned off for this release. You can update at any time by selecting <b>Help > Check for updates.</b>"
   },
   "update_complete_c5163fbf": {
     "message": "Update complete"
@@ -4144,6 +4207,9 @@
   },
   "warningsmsg_e2c04bfe": {
     "message": "{ warningsMsg }"
+  },
+  "we_detected_length_custom_obj_that_are_not_support_becd85f0": {
+    "message": "We detected { length } custom { obj } that are not support for Composer 2.0."
   },
   "we_need_to_define_the_endpoints_for_the_skill_to_a_5dc98d90": {
     "message": "We need to define the endpoints for the skill to allow other bots to interact with it."
@@ -4292,6 +4358,9 @@
   "your_bot_project_is_running_actionbutton_test_in_w_22d5f2de": {
     "message": "Your bot project is running. <actionButton>Test in Web Chat</actionButton>"
   },
+  "your_bot_s_microsoft_app_id_5f12844c": {
+    "message": "Your bot’s Microsoft App ID"
+  },
   "your_dialog_for_schemaid_was_generated_successfull_7471b82e": {
     "message": "Your dialog for \"{ schemaId }\" was generated successfully."
   },
@@ -4306,6 +4375,12 @@
   },
   "your_qna_maker_is_ready_it_took_time_minutes_to_co_88b29cf9": {
     "message": "Your QnA Maker is ready! It took { time } minutes to complete."
+  },
+  "your_root_bot_must_have_an_associated_microsoft_ap_91671242": {
+    "message": "Your root bot must have an associated Microsoft App ID and Password."
+  },
+  "your_root_bot_must_have_an_azure_publishing_profil_89055cfd": {
+    "message": "Your root bot must have an Azure publishing profile."
   },
   "your_skill_could_not_be_published_5bee6e6a": {
     "message": "Your skill could not be published."


### PR DESCRIPTION
* draft dialog

* ux css

* css

* jump to create profile & set microsoftAppId to publish target

* comments & lint

* refactor dialog wrapper

* fix publish types missing in provision dialog (#7697)

* test case

* refactor

* fix type define

* fix title and json parse

* fix app Id not sync when create new profile

* Adds AppID and Password sections

* test case fixed

* Adds AppID/Password

* Update copy

Co-authored-by: Soroush <hatpick@gmail.com>
Co-authored-by: Chris Whitten <christopher.whitten@microsoft.com>
Co-authored-by: Ben Yackley <61990921+beyackle@users.noreply.github.com>
Co-authored-by: VanyLaw <wenyluo@microsoft.com>
Co-authored-by: Lu Han <32191031+luhan2017@users.noreply.github.com>
Co-authored-by: Chris Whitten <christopherwhitten@gmail.com>

## Description

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
